### PR TITLE
add a code of conduct file.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Cray/HPE Open Source Community Code of Conduct
+
+## Contributor Code of Conduct
+
+As contributors and maintainers in the Cray/HPE community, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in the Cray/HPE community a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+## Scope 
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+## Reporting 
+
+For incidents occuring in the Cray/HPE community, contact the Cray/HPE Code of Conduct Committee via <cray_oss_conduct@hpe.com>.
+.
+
+## Enforcement 
+
+The Cray/HPE Code of Conduct Committee enforces code of conduct issues. 
+
+## Acknowledgements
+
+This Code of Conduct is adapted from the Contributor Covenant (http://contributor-covenant.org), version 2.0 available at http://contributor-covenant.org/version/2/0/code_of_conduct/


### PR DESCRIPTION
This is derived from Cray-HPE/Community and the CNCF
code of conduct, which is where the code of conduct found in that repo is
derived from.

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>