### PR TITLE
Workflow template for license-check

### DIFF
--- a/workflow-templates/license-check.properties.json
+++ b/workflow-templates/license-check.properties.json
@@ -1,0 +1,9 @@
+{
+    "name": "License Check",
+    "description": "Check if source files have appropriate license header",
+    "iconName": "shasta",
+    "categories": [
+        "Code review",
+        "Utilities"
+    ]
+}

--- a/workflow-templates/license-check.yml
+++ b/workflow-templates/license-check.yml
@@ -1,0 +1,15 @@
+name: license-check
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: License Check
+        uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest


### PR DESCRIPTION
License checkers runs on license-checker repository itself:
* https://github.com/Cray-HPE/license-checker/runs/4097229116?check_suite_focus=true - check unsuccessful (there are files without license)
* https://github.com/Cray-HPE/license-checker/runs/4097274047?check_suite_focus=true - check successful (all files fixed using the same license-checker in fix mode.

Check [license-checker README](https://github.com/Cray-HPE/license-checker/) for more details.