### PR TITLE
Add ability to ignore docker images when scanning them with snyk

### DIFF
--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -61,6 +61,11 @@ on:
         type: boolean
         required: false
         default: true
+      scan-images-ignore-list:
+        description: Images to ignore when scanning images with Snyk. This field is a JSON array of strings.
+        type: string
+        required: false
+        default: '[]'
       scan-image-snyk-args:
         description: Additional Snyk args when scanning images (e.g., `--severity-threshold=high`)
         type: string
@@ -221,4 +226,6 @@ jobs:
         with:
           image: ${{ matrix.image }}
           args: ${{ inputs.scan-image-snyk-args }}
+        if: ${{ !contains(fromJSON(inputs.scan-images-ignore-list), matrix.image) }}
+        
 


### PR DESCRIPTION
Add ability to ignore one or more docker images when scanning them with snyk. 

Example configuration to ignore a single image:
```yaml
with:
  scan-images-ignore-list: |
    [
      "artifactory.algol60.net/csm-docker/stable/cray-sls:latest",
    ]
```

Tested here: https://github.com/Cray-HPE/hms-sls-charts/actions/runs/1467925955 Only the image scan for `artifactory.algol60.net/csm-docker/stable/cray-sls:latest` was skipped.