### PR TITLE
Feature/sbom

### DIFF
--- a/actions/csm-generate-attach-sign-sbom/README.md
+++ b/actions/csm-generate-attach-sign-sbom/README.md
@@ -41,7 +41,7 @@ where in this case they point to the same version.
 | `cosign-gcp-project-id` | cosign project id in GCP | N/A |
 | `cosign-gcp-sa-key` | cosign service account key in GCP | N/A |
 | `cosign-key` | cosign application key | N/A |
-| `registry` | Docker registry to push image signature | `artifactory.algol60.net` |
+| `registry` | Docker registry to push image SBOM | `artifactory.algol60.net` |
 | `registry-username` | Container registry username | N/A |
 | `registry-password` | Container registry user password | N/A |
 | `github-sha` | Github commit SHA used to build the image | N/A |

--- a/actions/csm-generate-attach-sign-sbom/README.md
+++ b/actions/csm-generate-attach-sign-sbom/README.md
@@ -1,0 +1,68 @@
+# Generate, Attach, and Sign container image SBOM
+
+A GitHub action to generate SPDX Software Build of Materials (SBOM) using Syft
+from a given container image. The SBOM artifact is attached to the given 
+container image in a registry using cosign, and cosign is used to sign the SBOM. 
+
+
+## Usage
+
+```yaml
+  - name: Generate, Attach, and Sign container image SBOM
+    uses: Cray-HPE/.github/actions/csm-generate-attach-sign-sbom@v1-csm-generate-attach-sign-sbom
+    id: sbom
+    with:
+      cosign-gcp-project-id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+      cosign-gcp-sa-key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+      cosign-key: ${{ secrets.COSIGN_KEY }}
+      registry: artifactory.algol60.net
+      registry-username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+      registry-password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+      github-sha: ${{ env.GITHUB_SHA }}
+      image: ${{ steps.image-name.outputs.name }}:${{ steps.image-tag.outputs.tag }}
+```
+
+The action tag can include just the major, or may include the minor and patch
+version if desired for ensuring backwards compatibility. Versions are denoted
+by the SemVer followed by the action name, e.g.
+
+```
+    v1.0.0-csm-generate-attach-sign-sbom
+    v1.0-csm-generate-attach-sign-sbom
+    v1-csm-generate-attach-sign-sbom
+```
+where in this case they point to the same version.
+
+## Action Inputs
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `cosign-version` | Version of cosign-release to use | `v1.4.1` |
+| `cosign-gcp-project-id` | cosign project id in GCP | N/A |
+| `cosign-gcp-sa-key` | cosign service account key in GCP | N/A |
+| `cosign-key` | cosign application key | N/A |
+| `registry` | Docker registry to push image signature | `artifactory.algol60.net` |
+| `registry-username` | Container registry username | N/A |
+| `registry-password` | Container registry user password | N/A |
+| `github-sha` | Github commit SHA used to build the image | N/A |
+| `image` | Container image to generate a SBOM of | N/A |
+
+## Action outputs
+
+| Name | Description |
+| --- | --- |
+| `sbom-location` | Location in the registry where the SBOM was pushed to |
+
+
+## Action Behavior
+
+This action installs the `cosign-version` of cosign, logs in to the container
+registry, generates SBOM against the image using Syft, signs the SBOM, and 
+pushes the SBOM to the registry.
+
+For most CSM images and code repos, the cosign and registry parameters should
+be set by existing repository secrets.
+
+## License
+
+MIT

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -1,0 +1,88 @@
+name: 'Generate, Attach, and Sign container image SBOM'
+description: |
+  Use Syft to generate a SPDX SBOM from a container image. Then cosign is used to attach the
+  SBOM artifact to the given container image in a registry, and signs the SBOM. 
+inputs:
+  cosign-version:
+    required: false
+    description: Version of cosign-release to use
+    default: 'v1.4.1'
+  cosign-gcp-project-id:
+    required: true
+    description: cosign project id in GCP
+  cosign-gcp-sa-key:
+    required: true
+    description: cosign service account key in GCP
+  cosign-key:
+    required: true
+    description: cosign key
+  registry:
+    required: false
+    default: artifactory.algol60.net
+    descriptions: Registry to push image signature
+  registry-username:
+    required: true
+    description: Container registry username
+  registry-password:
+    required: true
+    description: Container registry user password
+  github-sha:
+    required: true
+    description: Github commit SHA used to build the image
+  image:
+    required: true
+    description: Image to sign
+outputs:
+  sbom-location:
+    description: Location in OCI Registry where the SBOM is located
+    value: ${{ steps.sbom-location.outputs.value }}
+runs:
+  using: "composite"
+  steps:
+  - name: Install cosign
+    uses: sigstore/cosign-installer@main
+    with:
+      cosign-release: ${{ inputs.cosign-version }}
+
+  - name: Install Syft
+    id: syft
+    uses: anchore/sbom-action/download-syft@v0
+
+  - name: Set up Cloud SDK for Signing
+    uses: google-github-actions/setup-gcloud@master
+    with:
+      project_id: ${{ inputs.cosign-gcp-project-id }}
+      service_account_key: ${{ inputs.cosign-gcp-sa-key }}
+      export_default_credentials: true
+
+  - name: Login to Registry
+    uses: docker/login-action@v1
+    with:
+      registry: ${{ inputs.registry }}
+      username: ${{ inputs.registry-username }}
+      password: ${{ inputs.registry-password }}
+
+  - name: Attach SBOM
+    env:
+      COSIGN_KEY: ${{ inputs.cosign-key }}
+      IMAGE: ${{ inputs.image }}
+    shell: bash
+    run: cosign attach sbom --sbom container_image.spdx $IMAGE
+
+  - name: Triangulate SBOM image Location
+    id: sbom-location
+    env:
+      COSIGN_KEY: ${{ inputs.cosign-key }}
+      IMAGE: ${{ inputs.image }}
+    shell: bash
+    run: |
+      SBOM_LOCATION=$(cosign triangulate --type sbom $IMAGE)
+      echo "::set-output name=value::$SBOM_LOCATION"
+
+  - name: Sign SBOM
+    env:
+      COSIGN_KEY: ${{ inputs.cosign-key }}
+      IMAGE: ${{ inputs.image }}
+      SBOM_LOCATION: ${{ steps.sbom-location.outputs.value }}
+    shell: bash
+    run: cosign sign --key $COSIGN_KEY $SBOM_LOCATION

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -1,7 +1,7 @@
 name: 'Generate, Attach, and Sign container image SBOM'
 description: |
-  Use Syft to generate a SPDX SBOM from a container image. Then cosign is used to attach the
-  SBOM artifact to the given container image in a registry, and signs the SBOM. 
+  Use Syft to generate a SPDX SBOM from a given container image. The SBOM artifact is attach the 
+  given container image using cosign in a registry, and cosign is used to sign the SBOM. 
 inputs:
   cosign-version:
     required: false

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -70,7 +70,6 @@ runs:
 
   - name: Attach SBOM
     env:
-      COSIGN_KEY: ${{ inputs.cosign-key }}
       IMAGE: ${{ inputs.image }}
     shell: bash
     run: cosign attach sbom --sbom container_image.spdx $IMAGE
@@ -78,17 +77,13 @@ runs:
   - name: Triangulate SBOM image Location
     id: sbom-location
     env:
-      COSIGN_KEY: ${{ inputs.cosign-key }}
       IMAGE: ${{ inputs.image }}
     shell: bash
-    run: |
-      SBOM_LOCATION=$(cosign triangulate --type sbom $IMAGE)
-      echo "::set-output name=value::$SBOM_LOCATION"
+    run: echo "::set-output name=value::$(cosign triangulate --type sbom $IMAGE)"
 
   - name: Sign SBOM
     env:
       COSIGN_KEY: ${{ inputs.cosign-key }}
-      IMAGE: ${{ inputs.image }}
       SBOM_LOCATION: ${{ steps.sbom-location.outputs.value }}
     shell: bash
     run: cosign sign --key $COSIGN_KEY $SBOM_LOCATION

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -86,4 +86,4 @@ runs:
       COSIGN_KEY: ${{ inputs.cosign-key }}
       SBOM_LOCATION: ${{ steps.sbom-location.outputs.value }}
     shell: bash
-    run: cosign sign --key $COSIGN_KEY $SBOM_LOCATION
+    run: cosign sign --key $COSIGN_KEY -a GIT_HASH=$GITHUB_SHA $SBOM_LOCATION

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -1,7 +1,7 @@
 name: 'Generate, Attach, and Sign container image SBOM'
 description: |
-  Use Syft to generate a SPDX SBOM from a given container image. The SBOM artifact is attach the 
-  given container image using cosign in a registry, and cosign is used to sign the SBOM. 
+  Use Syft to generate a SPDX SBOM from a given container image. The SBOM artifact is attached to the 
+  given container image in a registry using cosign, and cosign is used to sign the SBOM. 
 inputs:
   cosign-version:
     required: false

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -61,6 +61,12 @@ runs:
       registry: ${{ inputs.registry }}
       username: ${{ inputs.registry-username }}
       password: ${{ inputs.registry-password }}
+    
+  - name: Generate SBOM
+    shell: bash
+    env:
+      IMAGE: ${{ inputs.image }}
+    run: syft -vv packages $IMAGE --output spdx  > container_image.spdx
 
   - name: Attach SBOM
     env:

--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -19,7 +19,7 @@ inputs:
   registry:
     required: false
     default: artifactory.algol60.net
-    descriptions: Registry to push image signature
+    descriptions: Registry to push image SBOM
   registry-username:
     required: true
     description: Container registry username


### PR DESCRIPTION
## Summary and Scope

Add a github action to generate SPDX Software Build of Materials (SBOM) using Syft
from a given container image. The SBOM artifact is attached to the given 
container image in a registry using cosign, and cosign is used to sign the SBOM. 


## Testing
Github action run: https://github.com/Cray-HPE/hms-firmware-action/runs/4599570664?check_suite_focus=true

On my local machine I successfully downloaded the SBOM created from this PR run:
```
$ cosign download sbom artifactory.algol60.net/csm-docker/unstable/cray-firmware-action:1.17.1-20211221201229.ca09677b > container_image.spdx
```

Verified that the SBOM was signed:
```
$ cosign triangulate --type sbom artifactory.algol60.net/csm-docker/unstable/cray-firmware-action:1.17.1-20211221201229.ca09677b
artifactory.algol60.net/csm-docker/unstable/cray-firmware-action:sha256-a6bf32ac1dc295096e584753ed6cbdb92c4c447c5a1c5d568286044b864f2547.sbom
$ cosign verify --key github-cray-hpe-v1.pub artifactory.algol60.net/csm-docker/unstable/cray-firmware-action:sha256-a6bf32ac1dc295096e584753ed6cbdb92c4c447c5a1c5d568286044b864f2547.sbom

Verification for artifactory.algol60.net/csm-docker/unstable/cray-firmware-action:sha256-a6bf32ac1dc295096e584753ed6cbdb92c4c447c5a1c5d568286044b864f2547.sbom --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.

[{"critical":{"identity":{"docker-reference":"artifactory.algol60.net/csm-docker/unstable/cray-firmware-action"},"image":{"docker-manifest-digest":"sha256:3c94b031957ad54064bdf5c54b4c0404afc1e34cf9a4d31ac68d172a392f55d4"},"type":"cosign container image signature"},"optional":{"GIT_HASH":"ca09677bd4ddaa2a2404bfa1bbe2f48376d59502"}}]
```

## Risks and Mitigations
Low risk, nothing is using this yet.


