### PR TITLE
expose additional gitversion vars

### DIFF
--- a/actions/csm-run-build-prep/README.md
+++ b/actions/csm-run-build-prep/README.md
@@ -15,11 +15,11 @@ CSM Run Build Prep provides:
    built at the same time. For instance, if building a Docker image and Helm
    chart in a single workflow, the build timestamp can be used in both of their
    build metadata to get consistent version strings on the artifacts:
-
 ```
       csm-example-docker-image:1.2.3+20210728032600
       csm-example-helm-chart-1.2.3+20210728032600.tgz
 ```
+4. The Git "short" SHA (7 character prefix of the full Git SHA).
 
 ## Usage
 
@@ -61,9 +61,11 @@ where in this case they point to the same version.
 
 The following outputs can be used by subsequent workflow steps.
 
-- `version` - The computed version (string)
-- `is-stable` - If this build will produce stable artifacts based on `version` (boolean)
-- `build-date-time` - A timestamp useful as metadata for multiple artifacts in different jobs (format: `%Y%m%d%H%M%S`)
+| Name | Description | Example |
+| --- | --- | --- |
+| `version` | The computed semantic version (string) | `'1.2.4-beta.1'` |
+| `is-stable` | If this build will produce stable artifacts based on `version` | `'stable'` or `'unstable'` |
+| `build-date-time` | A timestamp useful as metadata for multiple artifacts in different jobs (format: `%Y%m%d%H%M%S`) | `20210728032600` |
 
 Step outputs can be accessed as in the following example.
 Note that in order to read the step outputs the action step must have an id.
@@ -78,6 +80,17 @@ Note that in order to read the step outputs the action step must have an id.
           echo "Stable - ${{ steps.buildprep.outputs.is-stable }}"
           echo "Build Timestamp - ${{ steps.buildprep.outputs.build-date-time }}"
 ```
+
+When `use-gitversion` is true, a set of additional computed version components
+are available:
+
+| Name | Description | Example |
+| --- | --- | --- |
+| `major` | Major version (string) | `'1'` |
+| `minor` | Minor version (string) | `'2'` |
+| `patch` | Patch version (string) | `'4'` |
+| `commits-since-last-version` | `CommitsSinceVersionSource` in the [GitVersion docs](https://gitversion.net/docs/reference/variables).  | `'10'` |
+
 
 ## Action Behavior
 

--- a/actions/csm-run-build-prep/action.yaml
+++ b/actions/csm-run-build-prep/action.yaml
@@ -23,11 +23,26 @@ outputs:
     description: The computed or discovered semantic version (string)
     value: ${{ steps.setversion.outputs.version }}
   is-stable:
-    description: If this build will produce stable artifacts (based on version)
+    description: If this build will produce stable artifacts (based on version), 'stable' or 'unstable'
     value: ${{ steps.setstable.outputs.is-stable }}
   build-date-time:
     description: 'A generated timestamp which can be used as metadata for multiple artifacts built in different jobs (format: %Y%m%d%H%M%S)'
     value: ${{ steps.date.outputs.buildtimestamp }}
+  major:
+    description: The computed major version (string) -- gitversion only
+    value: ${{ steps.gitversion-extra.outputs.major }}
+  minor:
+    description: The computed minor version (string) -- gitversion only
+    value: ${{ steps.gitversion-extra.outputs.minor }}
+  patch:
+    description: The computed patch version (string) -- gitversion only
+    value: ${{ steps.gitversion-extra.outputs.patch }}
+  short-sha:
+    description: The computed short commit SHA (length=7) (string) -- gitversion only
+    value: ${{ steps.gitversion-extra.outputs.short-sha }}
+  commits-since-last-version:
+    description: The computed number of commits since the last version (string) -- gitversion only -- see CommitsSinceVersionSource at https://gitversion.net/docs/reference/variables
+    value: ${{ steps.gitversion-extra.outputs.short-sha }}
 
 runs:
   using: "composite"
@@ -52,6 +67,17 @@ runs:
       if: ${{ inputs.use-gitversion }}
       id: gitversion
       uses: gittools/actions/gitversion/execute@v0.9.7
+
+    - name: Set a portion of regularly used GitVersion variables
+      if: ${{ inputs.use-gitversion }}
+      id: gitversion-extra
+      shell: bash
+      run: |
+        echo ::set-output name=major::$(echo '${{ steps.gitversion.outputs.Major }}')
+        echo ::set-output name=minor::$(echo '${{ steps.gitversion.outputs.Minor }}')
+        echo ::set-output name=patch::$(echo '${{ steps.gitversion.outputs.Patch }}')
+        echo ::set-output name=short-sha::$(echo '${{ steps.gitversion.outputs.ShortSha }}')
+        echo ::set-output name=commits-since-last-version::$(echo '${{ steps.gitversion.outputs.CommitsSinceVersionSource }}')
 
     - name: Get semantic version from file
       if: ${{ !inputs.use-gitversion }}


### PR DESCRIPTION
## Summary and Scope

Expose a few more variables provided by `gitversion`.

backwards compatible

## Testing

https://github.com/Cray-HPE/cray-product-catalog/runs/4599931860?check_suite_focus=true

## Risks and Mitigations

No, only one repo using this in feature development phase.
