### PR TITLE
Change GCP auth from deprecated SA token to Workload IdP

### DIFF
--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -71,12 +71,15 @@ runs:
     id: syft
     uses: anchore/sbom-action/download-syft@v0
 
-  - name: Set up Cloud SDK for Signing
-    uses: google-github-actions/setup-gcloud@v0
+  - name: Authenticate to Google Cloud
+    uses: google-github-actions/auth@v0
     with:
-      project_id: ${{ inputs.cosign-gcp-project-id }}
-      service_account_key: ${{ inputs.cosign-gcp-sa-key }}
-      export_default_credentials: true
+      workload_identity_provider: projects/672506737953/locations/global/workloadIdentityPools/github-cray-hpe/providers/github
+      service_account: cosign@sdlc-ops.iam.gserviceaccount.com
+      create_credentials_file: false
+
+  - name: Set up Cloud SDK
+    uses: google-github-actions/setup-gcloud@v0
 
   - name: Login to Registry
     uses: docker/login-action@v1

--- a/actions/csm-sign-image/action.yaml
+++ b/actions/csm-sign-image/action.yaml
@@ -62,12 +62,14 @@ runs:
       with:
         cosign-release: ${{ inputs.cosign-version }}
 
-    - name: Set up Cloud SDK for Signing
-      uses: google-github-actions/setup-gcloud@v0
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0
       with:
-        project_id: ${{ inputs.cosign-gcp-project-id }}
-        service_account_key: ${{ inputs.cosign-gcp-sa-key }}
-        export_default_credentials: true
+        workload_identity_provider: projects/672506737953/locations/global/workloadIdentityPools/github-cray-hpe/providers/github
+        service_account: cosign@sdlc-ops.iam.gserviceaccount.com
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0
 
     - name: Login to Registry
       uses: docker/login-action@v1


### PR DESCRIPTION
## Summary and Scope

See https://github.com/Cray-HPE/github-backup/pull/1

## Issues and Related PRs

* Resolves CASMCMS-7857

## Testing

* Used this branch to test in cray-product-catalog image building pipeline

### Tested on:

  * GH Actions pipeline https://github.com/Cray-HPE/cray-product-catalog/actions/runs/1917419150
