### PR TITLE
CRAYSAT-1535: Exclude SAT repositories from organization workflows

### DIFF
--- a/organization-workflows-settings.yml
+++ b/organization-workflows-settings.yml
@@ -27,4 +27,13 @@ exclude:
   repositories:
   - docs-csm
   - csm
+  - sat
+  - cfs-config-util
+  - sat-cfs-install
+  - docs-sat
+  - sat-install-utility
+  - sat-podman
+  - prodmgr
+  - sat-product-stream
+  - shasta-install-utility-common
 


### PR DESCRIPTION
## Summary and Scope

## Issues and Related PRs

* Part of [CRAYSAT-1535](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1535)
See also:
* https://github.com/Cray-HPE/sat/pull/53
* https://github.com/Cray-HPE/shasta-install-utility-common/pull/5
* https://github.com/Cray-HPE/sat-product-stream/pull/28
* https://github.com/Cray-HPE/prodmgr/pull/11
* https://github.com/Cray-HPE/sat-podman/pull/30
* https://github.com/Cray-HPE/sat-install-utility/pull/11
* https://github.com/Cray-HPE/docs-sat/pull/24
* https://github.com/Cray-HPE/sat-cfs-install/pull/14
* https://github.com/Cray-HPE/cfs-config-util/pull/8

## Testing

### Tested on:

* PR workflows

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable