### PR TITLE
CRAYSAT-1213: Exclude python-csm-api-client from organization workflows

### DIFF
--- a/organization-workflows-settings.yml
+++ b/organization-workflows-settings.yml
@@ -36,4 +36,5 @@ exclude:
   - prodmgr
   - sat-product-stream
   - shasta-install-utility-common
+  - python-csm-api-client
 


### PR DESCRIPTION
## Summary and Scope

This commit excludes the python-csm-api-client repository from the organization workflows, because the license checker is now being run via a repository-specific workflow.

## Issues and Related PRs

* Change needed to support [CRAYSAT-1213](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1213)

## Testing

### Tested on:

  * PR workflow


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

