### PR TITLE
Update docker/login-action to v2 in csm-sign-image and csm-generate-attach-sign-sbom

### DIFF
--- a/actions/csm-generate-attach-sign-sbom/action.yaml
+++ b/actions/csm-generate-attach-sign-sbom/action.yaml
@@ -82,7 +82,7 @@ runs:
     uses: google-github-actions/setup-gcloud@v0
 
   - name: Login to Registry
-    uses: docker/login-action@v1
+    uses: docker/login-action@v2
     with:
       registry: ${{ inputs.registry }}
       username: ${{ inputs.registry-username }}
@@ -105,7 +105,7 @@ runs:
     env:
       IMAGE: ${{ inputs.image }}
     shell: bash
-    run: echo "::set-output name=value::$(cosign triangulate --type sbom $IMAGE)"
+    run: echo "value=$(cosign triangulate --type sbom $IMAGE)" >> $GITHUB_OUTPUT
 
   - name: Sign SBOM
     env:

--- a/actions/csm-sign-image/action.yaml
+++ b/actions/csm-sign-image/action.yaml
@@ -72,7 +72,7 @@ runs:
       uses: google-github-actions/setup-gcloud@v0
 
     - name: Login to Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
[The ::set-output command is deprecated, and will be disabled in May of 2023.  ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). 

- Update docker/login-action to v2 in csm-sign-image and csm-generate-attach-sign-sbom actions to pickup changes for ::set-output.
- Also updated csm-generate-attach-sign-sbom to use GITHUB_OUTPUT file, instead of ::set-output. 

Now when these actions run they no longer emit deprecation warnings. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatibile. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

These changes have been tested in this github action run, while testing changes to the HMS build workflows: https://github.com/Cray-HPE/hms-canary/actions/runs/3679099574/jobs/6260603293

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

