### PR TITLE
Added chart-directory option to k8s api checker

### DIFF
--- a/actions/csm-k8s-api-checker/README.md
+++ b/actions/csm-k8s-api-checker/README.md
@@ -65,6 +65,7 @@ Note all are optional, but realistically prerequisite needs to be set per repo.
 | `enable-pr-comment` | Comment in pr or not | true |
 | `fail-on-removed` | If a pr should fail if removed apis are found | true |
 | `fail-on-deprecated` | If a pr should fail if deprecated apis are found | false |
+| `chart-directory` | The directory under which to search for chart files | . |
 
 ## Action outputs
 

--- a/actions/csm-k8s-api-checker/action.yaml
+++ b/actions/csm-k8s-api-checker/action.yaml
@@ -40,6 +40,10 @@ inputs:
     required: false
     default: "false"
     description: "If this action should fail if deprecated apis are found i.e.: true/false"
+  chart-directory:
+    required: false
+    default: "."
+    description: "The directory under which to search for chart files"
 
   # TODO: Future me add a target version so we can control what version of k8s
   # we're wanting to complain about.
@@ -98,12 +102,13 @@ runs:
 
           ${{ inputs.prerequisite }}
 
+          dir=${{ inputs.chart-directory }}
           complain=false
 
-          if [ "$(pluto detect-files --ignore-deprecations --ignore-removals 2>&1)" != "There were no resources found with known deprecated apiVersions." ]; then
+          if [ "$(pluto detect-files --ignore-deprecations --ignore-removals --directory $dir 2>&1)" != "There were no resources found with known deprecated apiVersions." ]; then
             complain=true
-            pluto detect-files --output custom --columns DEPRECATED,REMOVED,NAME,KIND,VERSION --ignore-deprecations --ignore-removals > lhs
-            pluto detect-files --output custom --columns REPLACEMENT --ignore-deprecations --ignore-removals > rhs
+            pluto detect-files --output custom --columns DEPRECATED,REMOVED,NAME,KIND,VERSION --ignore-deprecations --ignore-removals --directory $dir > lhs
+            pluto detect-files --output custom --columns REPLACEMENT --ignore-deprecations --ignore-removals --directory $dir > rhs
             paste lhs rhs | sed '/^[[:space:]]*$/d' > plutooutput
 
             # This is a huge hack, future me fix it, past me is just sorry
@@ -155,6 +160,8 @@ runs:
           if ! ${{ inputs.fail-on-deprecated }}; then
             args="${args} --ignore-deprecations"
           fi
+          dir=${{ inputs.chart-directory }}
+          args="${args} --directory $dir"
 
           # The actual run to determine if things are yea/nay the above is all
           # lies for filling out the comment with data on what is/n't ok. This


### PR DESCRIPTION
## Summary and Scope

Added option to the k8s api checker to allow the client to specify the directory to search for chart files.

## Issues and Related PRs

* Resolves [CASMHMS-5842](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5842)

## Testing

### Tested on:

  * github

### Test description:

Tested on hms projects.

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

