### PR TITLE
Added option to set pluto's component versions

### DIFF
--- a/actions/csm-k8s-api-checker/action.yaml
+++ b/actions/csm-k8s-api-checker/action.yaml
@@ -68,6 +68,10 @@ inputs:
     description: "tag for container image, i.e.: latest"
     default: "latest"
     required: false
+  PLUTO_COMPONENT_VERSIONS:
+    description: "The component versions, separated by commas, in the form that the pluto command uses. e.g. k8s=v1.21.0,cert-manager=v0.14.1"
+    default: ""
+    required: false
 runs:
   using: "composite"
     # if: ${{ fromJSON(inputs.enable-pr-comment) && github.event_name == 'pull_request' }}
@@ -103,16 +107,25 @@ runs:
           ${{ inputs.prerequisite }}
 
           dir=${{ inputs.chart-directory }}
+
+          # The following converts "k8s=v1.21.0,cert-manager=v0.14.1" to "--target-versions k8s=v1.21.0 --target-versions cert-manager=v0.14.1 "
+          component_versions=$(echo ${{ inputs.PLUTO_COMPONENT_VERSIONS }} | awk -v RS=',' '{if($1!=""){printf "--target-versions %s ", $1}}' )
+
           complain=false
 
-          if [ "$(pluto detect-files --ignore-deprecations --ignore-removals --directory $dir 2>&1)" != "There were no resources found with known deprecated apiVersions." ]; then
+          if ! pluto detect-files --directory $dir $component_versions; then
             complain=true
-            pluto detect-files --output custom --columns DEPRECATED,REMOVED,NAME,KIND,VERSION --ignore-deprecations --ignore-removals --directory $dir > lhs
-            pluto detect-files --output custom --columns REPLACEMENT --ignore-deprecations --ignore-removals --directory $dir > rhs
-            paste lhs rhs | sed '/^[[:space:]]*$/d' > plutooutput
+            pluto detect-files --directory $dir $component_versions --ignore-deprecations --ignore-removals --output custom --columns DEPRECATED,REMOVED,NAME,KIND,VERSION,COMPONENT,'DEPRECATED IN','REMOVED IN' > lhs
+            pluto detect-files --directory $dir $component_versions --ignore-deprecations --ignore-removals --output custom --columns REPLACEMENT > rhs
+            paste lhs rhs |
+              sed '/^[[:space:]]*$/d' |
+              sed 's/DEPRECATED IN/DEPRECATED-IN/' |
+              sed 's/REMOVED IN/REMOVED-IN/' > plutooutput
 
             # This is a huge hack, future me fix it, past me is just sorry
-            cat plutooutput | awk '{print "| " $1 " | " $2 " | " $3 " | " $4 " | " $5 " | " $6 " |"}' | awk '1; NR==1{gsub(/[^|]/,"-"); print;}' > plutomd
+            cat plutooutput |
+              awk '{print "| " $1 " | " $2 " | " $3 " | " $4 " | " $5 " | " $6 " | " $7 " | " $8 " |"}' |
+              awk '1; NR==1{gsub(/[^|]/,"-"); print;}' > plutomd
 
             cat <<EOF > comment.txt
             Deprecated or removed api's detected, reference upstream documentation for full details on specific api changes:
@@ -154,14 +167,19 @@ runs:
         run: |
           set -x
           args=
+
+          dir=${{ inputs.chart-directory }}
+          args="${args} --directory $dir"
+
+          component_versions=$(echo ${{ inputs.PLUTO_COMPONENT_VERSIONS }} | awk -v RS=',' '{if($1!=""){printf "--target-versions %s ", $1}}' )
+          args="${args} $component_versions"
+
           if ! ${{ inputs.fail-on-removed }}; then
             args="--ignore-removed"
           fi
           if ! ${{ inputs.fail-on-deprecated }}; then
             args="${args} --ignore-deprecations"
           fi
-          dir=${{ inputs.chart-directory }}
-          args="${args} --directory $dir"
 
           # The actual run to determine if things are yea/nay the above is all
           # lies for filling out the comment with data on what is/n't ok. This


### PR DESCRIPTION
## Summary and Scope

Added option to set the k8s component versions on the pluto cli calls in the csm-k8s-api-checker action.

## Issues and Related PRs

* Resolves [CASMHMS-5896](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5896)

## Testing

### Tested on:

  * Tested on hms github workflows

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

