### PR TITLE
CASMINST-7278 Update license-check template and workflow

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,20 +29,8 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
-
-    container:
-      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      credentials:
-          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v35
-
-    - name: License Check
-      if: ${{ steps.changed-files.outputs.all_changed_files }}
-      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}
+      - uses: Cray-HPE/license-checker@v2

--- a/workflow-templates/license-check.yaml
+++ b/workflow-templates/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,25 +21,16 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-name: license-check
+name: Check Licenses
 
 on:
-  push:
-  workflow_dispatch:
+  pull_request:
 
 jobs:
   license-check:
     runs-on: ubuntu-latest
-
-    container:
-      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      credentials:
-          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+    permissions:
+      contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: License Check
-        run: /usr/local/bin/python3 /license_check/license_check.py
+      - uses: Cray-HPE/license-checker@v2


### PR DESCRIPTION
## Summary and Scope

* Convert license-check check on this repo to org workflow (remove local wokflow file)
* Update license-checker template for installtion in other repos

## Issues and Related PRs

* Resolves [CASMINST-7278](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7278)

## Testing
### Tested on:

Enforcement of license check on this PR provides a test.